### PR TITLE
fix URL for CR2

### DIFF
--- a/wot-thing-description/Overview.html
+++ b/wot-thing-description/Overview.html
@@ -933,7 +933,7 @@
 </head>
 <body class="h-entry toc-inline">
   <p>【注意】 この文書は、<a href=
-  "https://www.w3.org/TR/2020/CR-wot-thing-description-20201106/">2019年11月6日付の
+  "https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/">2019年11月6日付の
   W3C勧告候補「Web of Things (WoT) Thing Description」(原文は英語)</a>を、WoT JP
   Commuityが翻訳と修正をおこなって公開しているものです。この文書の正式版は、あくまでW3Cのサイト内にある英語版であり、この文書には翻訳上の間違い、あるいは不適切な表現が含まれている可能性がありますのでご注意ください。</p>
   <hr>


### PR DESCRIPTION
"https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/" に修正．